### PR TITLE
Update ACProgressView.swift

### DIFF
--- a/Source/ACProgressView.swift
+++ b/Source/ACProgressView.swift
@@ -146,8 +146,8 @@ fileprivate extension ACProgressView {
     }
     
     func loadViewFromNib() -> UIView {
-        
-        let bundle = Bundle.main
+       
+        let bundle = Bundle(for: ACProgressView.self)
         let nib = UINib(nibName: "ACProgressView", bundle: bundle)
         let view = nib.instantiate(withOwner: self, options: nil)[0] as! UIView
         


### PR DESCRIPTION
Resolved the crash  while loading the 'ACProgressView.xib' from the Bundle.